### PR TITLE
feat: Support authentication from Auth Action

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ npm install @google-github-actions/setup-cloud-sdk
 ```TS
 import * as core from '@actions/core';
 import * as toolCache from '@actions/tool-cache';
-import * as setupGcloud from 'setup-cloud-sdk';
+import * as setupGcloud from '@google-github-actions/setup-cloud-sdk';
 
 // Install gcloud if not already installed.
 const gcloudVersion = await setupGcloud.getLatestGcloudSDKVersion();

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -34,7 +34,7 @@ param is supported for legacy Actions.
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `serviceAccountKey?` | `string` | `undefined` | The service account key used for authentication. |
-| `silent` | `boolean` | `true` | - |
+| `silent` | `boolean` | `true` | Skip writing output to sdout. |
 
 #### Returns
 
@@ -44,7 +44,7 @@ exit code.
 
 #### Defined in
 
-[index.ts:200](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L200)
+[index.ts:201](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L201)
 
 ___
 
@@ -60,7 +60,7 @@ The latest stable version of the gcloud SDK.
 
 #### Defined in
 
-[version-util.ts:27](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/version-util.ts#L27)
+[version-util.ts:27](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/version-util.ts#L27)
 
 ___
 
@@ -78,7 +78,7 @@ gcloud command.
 
 #### Defined in
 
-[index.ts:50](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L50)
+[index.ts:50](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L50)
 
 ___
 
@@ -103,7 +103,7 @@ CMD output
 
 #### Defined in
 
-[index.ts:320](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L320)
+[index.ts:321](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L321)
 
 ___
 
@@ -127,7 +127,7 @@ The path of the installed tool.
 
 #### Defined in
 
-[index.ts:120](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L120)
+[index.ts:120](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L120)
 
 ___
 
@@ -151,7 +151,7 @@ true is gcloud is authenticated.
 
 #### Defined in
 
-[index.ts:92](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L92)
+[index.ts:92](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L92)
 
 ___
 
@@ -175,7 +175,7 @@ true if gcloud is found in toolpath.
 
 #### Defined in
 
-[index.ts:35](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L35)
+[index.ts:35](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L35)
 
 ___
 
@@ -199,7 +199,7 @@ true is project Id is set.
 
 #### Defined in
 
-[index.ts:65](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L65)
+[index.ts:65](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L65)
 
 ___
 
@@ -223,7 +223,7 @@ ServiceAccountKey as an object.
 
 #### Defined in
 
-[index.ts:142](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L142)
+[index.ts:142](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L142)
 
 ___
 
@@ -248,7 +248,7 @@ CMD output
 
 #### Defined in
 
-[index.ts:349](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L349)
+[index.ts:350](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L350)
 
 ___
 
@@ -273,7 +273,7 @@ project ID.
 
 #### Defined in
 
-[index.ts:285](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L285)
+[index.ts:286](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L286)
 
 ___
 
@@ -297,4 +297,4 @@ project ID.
 
 #### Defined in
 
-[index.ts:306](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L306)
+[index.ts:307](https://github.com/google-github-actions/setup-cloud-sdk/blob/ed4039f/src/index.ts#L307)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -23,15 +23,17 @@
 
 ### authenticateGcloudSDK
 
-▸ **authenticateGcloudSDK**(`serviceAccountKey`, `silent?`): `Promise`<`number`\>
+▸ **authenticateGcloudSDK**(`serviceAccountKey?`, `silent?`): `Promise`<`number`\>
 
-Authenticates the gcloud tool using a service account key.
+Authenticates the gcloud tool using a service account key or WIF credential configuration
+discovered via GOOGLE_GHA_CREDS_PATH environment variable. An optional serviceAccountKey
+param is supported for legacy Actions.
 
 #### Parameters
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
-| `serviceAccountKey` | `string` | `undefined` | The service account key used for authentication. |
+| `serviceAccountKey?` | `string` | `undefined` | The service account key used for authentication. |
 | `silent` | `boolean` | `true` | - |
 
 #### Returns
@@ -42,7 +44,7 @@ exit code.
 
 #### Defined in
 
-[index.ts:182](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L182)
+[index.ts:200](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L200)
 
 ___
 
@@ -58,7 +60,7 @@ The latest stable version of the gcloud SDK.
 
 #### Defined in
 
-[version-util.ts:27](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/version-util.ts#L27)
+[version-util.ts:27](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/version-util.ts#L27)
 
 ___
 
@@ -76,7 +78,7 @@ gcloud command.
 
 #### Defined in
 
-[index.ts:49](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L49)
+[index.ts:50](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L50)
 
 ___
 
@@ -101,7 +103,7 @@ CMD output
 
 #### Defined in
 
-[index.ts:250](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L250)
+[index.ts:320](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L320)
 
 ___
 
@@ -125,7 +127,7 @@ The path of the installed tool.
 
 #### Defined in
 
-[index.ts:119](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L119)
+[index.ts:120](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L120)
 
 ___
 
@@ -149,7 +151,7 @@ true is gcloud is authenticated.
 
 #### Defined in
 
-[index.ts:91](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L91)
+[index.ts:92](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L92)
 
 ___
 
@@ -173,7 +175,7 @@ true if gcloud is found in toolpath.
 
 #### Defined in
 
-[index.ts:34](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L34)
+[index.ts:35](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L35)
 
 ___
 
@@ -197,7 +199,7 @@ true is project Id is set.
 
 #### Defined in
 
-[index.ts:64](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L64)
+[index.ts:65](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L65)
 
 ___
 
@@ -221,7 +223,7 @@ ServiceAccountKey as an object.
 
 #### Defined in
 
-[index.ts:141](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L141)
+[index.ts:142](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L142)
 
 ___
 
@@ -246,7 +248,7 @@ CMD output
 
 #### Defined in
 
-[index.ts:279](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L279)
+[index.ts:349](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L349)
 
 ___
 
@@ -271,7 +273,7 @@ project ID.
 
 #### Defined in
 
-[index.ts:215](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L215)
+[index.ts:285](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L285)
 
 ___
 
@@ -295,4 +297,4 @@ project ID.
 
 #### Defined in
 
-[index.ts:236](https://github.com/google-github-actions/setup-cloud-sdk/blob/3de11b9/src/index.ts#L236)
+[index.ts:306](https://github.com/google-github-actions/setup-cloud-sdk/blob/96713e3/src/index.ts#L306)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@types/chai-as-promised": "^7.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.11.10",
+        "@types/sinon": "^10.0.6",
+        "@types/uuid": "^8.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "@vercel/ncc": "^0.32.0",
@@ -30,10 +32,12 @@
         "eslint-plugin-prettier": "^4.0.0",
         "mocha": "^9.1.2",
         "prettier": "^2.4.1",
+        "sinon": "^12.0.1",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.9",
         "typedoc-plugin-markdown": "^3.11.7",
-        "typescript": "^4.4.4"
+        "typescript": "^4.4.4",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@actions/core": {
@@ -76,6 +80,15 @@
         "@actions/io": "^1.1.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/@actions/tool-cache/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -188,6 +201,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -243,6 +291,30 @@
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
       "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
+      "integrity": "sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/fake-timers": "^7.1.0"
+      }
+    },
+    "node_modules/@types/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1655,6 +1727,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1691,6 +1769,12 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1718,6 +1802,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -1908,6 +1998,28 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2027,6 +2139,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
       }
     },
     "node_modules/path-type": {
@@ -2323,6 +2444,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
+      "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^8.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/slash": {
@@ -2628,12 +2767,12 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -2827,6 +2966,13 @@
         "@actions/io": "^1.1.1",
         "semver": "^6.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "@cspotcode/source-map-consumer": {
@@ -2917,6 +3063,41 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+      "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -2972,6 +3153,32 @@
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
       "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
+      "integrity": "sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/fake-timers": "^7.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
+      }
+    },
+    "@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -3977,6 +4184,12 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4010,6 +4223,12 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4028,6 +4247,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -4176,6 +4401,30 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4263,6 +4512,15 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -4443,6 +4701,20 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      }
+    },
+    "sinon": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
+      "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^8.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
       }
     },
     "slash": {
@@ -4652,9 +4924,10 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.11.10",
         "@types/sinon": "^10.0.6",
-        "@types/uuid": "^8.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "@vercel/ncc": "^0.32.0",
@@ -36,8 +35,7 @@
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.9",
         "typedoc-plugin-markdown": "^3.11.7",
-        "typescript": "^4.4.4",
-        "uuid": "^8.3.2"
+        "typescript": "^4.4.4"
       }
     },
     "node_modules/@actions/core": {
@@ -310,12 +308,6 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
-      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.4.0",
@@ -2766,15 +2758,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -3174,12 +3157,6 @@
           }
         }
       }
-    },
-    "@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
-      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.4.0",
@@ -4922,12 +4899,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.10",
+    "@types/sinon": "^10.0.6",
+    "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "@vercel/ncc": "^0.32.0",
@@ -47,9 +49,11 @@
     "eslint-plugin-prettier": "^4.0.0",
     "mocha": "^9.1.2",
     "prettier": "^2.4.1",
+    "sinon": "^12.0.1",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.9",
     "typedoc-plugin-markdown": "^3.11.7",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.10",
     "@types/sinon": "^10.0.6",
-    "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "@vercel/ncc": "^0.32.0",
@@ -53,7 +52,6 @@
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.9",
     "typedoc-plugin-markdown": "^3.11.7",
-    "typescript": "^4.4.4",
-    "uuid": "^8.3.2"
+    "typescript": "^4.4.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ function isWIFCredFile(credFile: string): boolean {
 
 /**
  * Authenticates the gcloud tool using a service account key or WIF credential configuration
- * discovered via GOOGLE_GHA_CREDS_PATH environment variable. An explicit serviceAccountKey
+ * discovered via GOOGLE_GHA_CREDS_PATH environment variable. An optional serviceAccountKey
  * param is supported for legacy Actions.
  *
  * @param serviceAccountKey - The service account key used for authentication.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import * as downloadUtil from './download-util';
 import * as installUtil from './install-util';
 import { getLatestGcloudSDKVersion } from './version-util';
 import { ExecOptions } from '@actions/exec/lib/interfaces';
+import * as fs from 'fs';
 
 export { getLatestGcloudSDKVersion };
 
@@ -174,12 +175,60 @@ export function parseServiceAccountKey(
 }
 
 /**
- * Authenticates the gcloud tool using a service account key.
+ * Check if a given credential is WIF credential configuration.
+ *
+ * @param credFile - The  WIF credential configuration.
+ * @returns boolean.
+ */
+function isWIFCredFile(credFile: string): boolean {
+  try {
+    const creds = JSON.parse(credFile);
+    return 'type' in creds && creds.type == 'external_account';
+  } catch (err) {
+    throw new SyntaxError(`Failed to parse credentials as JSON: ${err}`);
+  }
+}
+
+/**
+ * Authenticates the gcloud tool using a service account key or WIF credential configuration
+ * discovered via GOOGLE_GHA_CREDS_PATH environment variable. An explicit serviceAccountKey
+ * param is supported for legacy Actions.
  *
  * @param serviceAccountKey - The service account key used for authentication.
  * @returns exit code.
  */
 export async function authenticateGcloudSDK(
+  serviceAccountKey?: string,
+  silent = true,
+): Promise<number> {
+  // Check if GOOGLE_GHA_CREDS_PATH has been set by auth
+  if (process.env.GOOGLE_GHA_CREDS_PATH) {
+    const credFilePath = process.env.GOOGLE_GHA_CREDS_PATH;
+    const credFile = await fs.promises.readFile(credFilePath, 'utf8');
+    // Check if credential is a WIF creds file
+    if (isWIFCredFile(credFile)) {
+      return authGcloudWIFCredsFile(credFilePath, silent);
+    }
+    return authGcloudSAKey(credFile, silent);
+  }
+  // Support legacy actions that pass in SA key
+  if (serviceAccountKey) {
+    return authGcloudSAKey(serviceAccountKey, silent);
+  }
+  // One of GOOGLE_GHA_CREDS_PATH or SA key is required
+  throw new Error(
+    'Error authenticating the Cloud SDK. Please use `google-github-actions/auth` to export credentials.',
+  );
+}
+
+/**
+ * Authenticates the gcloud tool using a service account key.
+ *
+ * @param serviceAccountKey - The service account key used for authentication.
+ * @returns exit code.
+ */
+
+async function authGcloudSAKey(
   serviceAccountKey: string,
   silent = true,
 ): Promise<number> {
@@ -202,6 +251,27 @@ export async function authenticateGcloudSDK(
       '--key-file',
       '-',
     ],
+    options as ExecOptions,
+  );
+}
+
+/**
+ * Authenticates the gcloud tool using WIF credential configuration.
+ *
+ * @param credsFile - The WIF credential configuration path.
+ * @returns exit code.
+ */
+async function authGcloudWIFCredsFile(
+  credFilePath: string,
+  silent = true,
+): Promise<number> {
+  const toolCommand = getToolCommand();
+  const options = {
+    silent,
+  };
+  return await exec.exec(
+    toolCommand,
+    ['--quiet', 'auth', 'login', '--cred-file', credFilePath],
     options as ExecOptions,
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import * as downloadUtil from './download-util';
 import * as installUtil from './install-util';
 import { getLatestGcloudSDKVersion } from './version-util';
 import { ExecOptions } from '@actions/exec/lib/interfaces';
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 
 export { getLatestGcloudSDKVersion };
 
@@ -195,6 +195,7 @@ function isWIFCredFile(credFile: string): boolean {
  * param is supported for legacy Actions.
  *
  * @param serviceAccountKey - The service account key used for authentication.
+ * @param silent - Skip writing output to sdout.
  * @returns exit code.
  */
 export async function authenticateGcloudSDK(
@@ -204,7 +205,7 @@ export async function authenticateGcloudSDK(
   // Check if GOOGLE_GHA_CREDS_PATH has been set by auth
   if (process.env.GOOGLE_GHA_CREDS_PATH) {
     const credFilePath = process.env.GOOGLE_GHA_CREDS_PATH;
-    const credFile = await fs.promises.readFile(credFilePath, 'utf8');
+    const credFile = await fs.readFile(credFilePath, 'utf8');
     // Check if credential is a WIF creds file
     if (isWIFCredFile(credFile)) {
       return authGcloudWIFCredsFile(credFilePath, silent);

--- a/src/test-util.ts
+++ b/src/test-util.ts
@@ -18,6 +18,9 @@
  * A collection of utility functions for testing.
  */
 import * as path from 'path';
+import * as os from 'os';
+import { v4 as uuidv4 } from 'uuid';
+import { promises as fs } from 'fs';
 
 /**
  * Creates an overridden runner cache and tool path. This is slightly
@@ -56,6 +59,18 @@ export class TestToolCache {
   }
 }
 
+export const TEST_TMP_FILES_DIR = path.join(os.tmpdir(), 'test-setupcloudsdk');
+
+/**
+ * Helper to write test data to disk.
+ */
+export async function writeTmpFile(data: string): Promise<string> {
+  const tmpDir = await fs.mkdtemp(TEST_TMP_FILES_DIR);
+  const tmpFile = path.join(tmpDir, uuidv4());
+  await fs.writeFile(tmpFile, data);
+  return tmpFile;
+}
+
 /**
  * The version of the gcloud SDK being tested against.
  */
@@ -68,3 +83,38 @@ export const TEST_SDK_VERSIONS = [
 ];
 
 export const TEST_SDK_VERSION = TEST_SDK_VERSIONS[TEST_SDK_VERSIONS.length - 1];
+
+export const TEST_WIF_CREDS_FILE = `
+{
+  "audience": "//iam.googleapis.com/my-provider",
+  "credential_source": {
+    "format": {
+      "subject_token_field_name": "value",
+      "type": "json"
+    },
+    "headers": {
+      "Authorization": "Bearer github-token"
+    },
+    "url": "https://actions-token.url/?audience=my-aud"
+  },
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/my-service@my-project.iam.gserviceaccount.com:generateAccessToken",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "type": "external_account"
+}
+`;
+
+export const TEST_SA_KEY_CREDS_FILE = `
+{
+  "type": "service_account",
+  "project_id": "my-project",
+  "private_key_id": "1234567890abcdefghijklmnopqrstuvwxyzaabb",
+  "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCRVYIJRuxdujaX\\nUfyY9mXT1O0M3PwyT+FnPJVY+6Md7KMiPKpZRYt7okj51Ln1FLcb9mY17LzPEAxS\\nBPn1LWNpSJpmttI/D3U+bG/znf/E89ErVopYWpaynbYrb/Mu478IE9TgvnqJMlkj\\nlQbaxnZ7qhnbI5h6p/HINWfY7xBDGZM1sc2FK9KbNfEzLdW1YiK/lWAwtfM7rbiO\\nZj+LnWm2dgwZxu0h8m68qYYMywzLcV3NTe35qdAznasc1WQvJikY+N82Wu+HjsPa\\nH0fLE3gN5r+BzDYQxEQnWANgxlsHeN9mg5LAg5fyTBwTS7Ato/qQ07da0CSoS1M0\\nriYvuCzhAgMBAAECggEAAai+m9fG5B03kIMLpY5O7Rv9AM+ufb91hx6Nwkp7r4M5\\nt11vY7I96wuYJ92iBu8m4XR6fGw0Xz3gkcQ69ZCu5320hBdPrJsrqXwMhgxgoGcq\\nWuB8aJEWASi+T9hGENA++eDQFMupWV6HafzCdxd4NKAfmZ/xf1OFUu0TVpvxKlAD\\ne6Njz/5+QFdUcNioi7iGy1Qz7xdpClEWdVin8VWe3p6UsCLfHmQfPPuLXOvpBj6k\\niFu9dl93z+8vlDLoAyXSaDeYyRMBGVOBM36cICuVpxfV1s/corEZXhz3aI8mlYiQ\\n6YXTcEnllt+NTJDIL99CnYn+WBVzeIGXtr0EKAyM6QKBgQDCU6FDvU0P8qt45BDm\\nSP2V7uMoI32mjEA3plJzqqSZ9ritxFmylrOttOoTYH2FVjrKPZZsLihSjpmm+wEz\\nGfjd75eSJYAb/m7GNOqbJjqAJIbIMaHfVcH6ODT2b0Tc8v/CK0PZy/jzgt68TdtF\\no462tr8isj7yLpCGdoLq9iq4gwKBgQC/dWTGFnaI08v1uqx6derf+qikSsjlYh4L\\nDdTlI8/eaTR90PFPQ4a8LE8pmhMhkJNg87jAF5VF29sPmlpfKbOC87C2iI8uIHcn\\nu0sTdhn6SukyUSN/eeb1KSDJuxDvIgPRTZj6XMlUulADeLRnlAoWOe0tu/wqpse6\\nB0Qu2oAfywKBgQCMWukESyro1OZit585JQj7jQJG0HOFopETYK722g5vIdM7trDu\\nm4iFc0EJ48xlTOXDgv4tfp0jG9oA0BSKuzyT1+RK64j/LyMFR90XWGIyga9T0v1O\\nmNs1BfnC8JT1XRG7RZKJMZjLEQAdU8KHJt4CPDYLMmDifR1n8RsX59rtTwKBgQCS\\nnAmsKn1gb5cqt2Tmba+LDj3feSj3hjftTQ0u3kqKTNOWWM7AXLwrEl8YQ1TNChHh\\nVyCtcCGtmhrYiuETKDK/X259iHrj3paABUsLPw/Le1uxXTKqpiV2rKTf9XCVPd3g\\ng+RWK4E8cWNeFStIebNzq630rJP/8TDWQkQzALzGGwKBgQC5bnlmipIGhtX2pP92\\niBM8fJC7QXbyYyamriyFjC3o250hHy7mZZG7bd0bH3gw0NdC+OZIBNv7AoNhjsvP\\nuE0Qp/vQXpgHEeYFyfWn6PyHGzqKLFMZ/+iCTuy8Iebs1p5DZY8RMXpx4tv6NfRy\\nbxHUjlOgP7xmXM+OZpNymFlRkg==\\n-----END PRIVATE KEY-----\\n",
+  "client_email": "my-service-account@my-project.iam.gserviceaccount.com",
+  "client_id": "123456789098765432101",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-service-account%40my-project.iam.gserviceaccount.com"
+}
+`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -180,7 +180,7 @@ describe('#setupCloudSDK', function () {
   });
 
   it('throws an error if GOOGLE_GHA_CREDS_PATH is not set and SA key is not provided', async function () {
-    // await setupCloudSDK.installGcloudSDK(version);
+    await setupCloudSDK.installGcloudSDK(version);
     try {
       await setupCloudSDK.authenticateGcloudSDK();
     } catch (err) {


### PR DESCRIPTION
This adds support for discovering `GOOGLE_GHA_CREDS_PATH` set by Auth(https://github.com/google-github-actions/auth/pull/57) and WIF credentials file.

This is backwards compatible allowing other gcloud Actions to support both explicit credentials and authentication via Auth Action.