### PR TITLE
feat: add gcloudRun and use getExecOutput

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,7 +29,7 @@ jobs:
         - 'macos-11'
         node:
         - '12'
-        - '14'
+        - '16'
     steps:
     - uses: 'actions/checkout@v2'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,17 +16,23 @@
 
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
+    "alwaysStrict": true,
     "declaration": true,
-    "lib": [
-      "es6"
-    ],
+    "esModuleInterop": true,
+    "lib": ["es6"],
+    "module": "commonjs",
+    "noImplicitAny": true,
     "outDir": "./dist",
     "rootDir": "./src",
+    "sourceMap": true,
     "strict": true,
-    "noImplicitAny": true,
-    "esModuleInterop": true
+    "target": "es6"
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["dist/**/*", "node_modules", "**/*.test.ts"],
+  "typedocOptions": {
+    "entryPoints": ["./src"],
+    "entryPointStrategy": "expand",
+    "gitRevision": "main",
+    "out": "./docs"
+  }
 }


### PR DESCRIPTION
This introduces two new functions `gcloudRun` and `gcloudRunJSON` which use `@actions/exec#getExecOutput` to execute gcloud commands. It checks if the command was successful. On failure, it throws an error and prints stderr and stdout. On success, it returns the stderr, stdout, and combined output.

Introducing this function also greatly simplified some of the other functions, which had a lot of duplicate logic, etc.

I also refactored the tests a bit to reduce the number of times we actually install gcloud. This made the tests significantly faster (~5min -> ~40s).