### PR TITLE
Add a workflow for getting gcloud versions

### DIFF
--- a/.github/workflows/compile-versions.yml
+++ b/.github/workflows/compile-versions.yml
@@ -1,0 +1,102 @@
+name: 'Compile versions'
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  PR_BRANCH: 'actions/gcloud-versions'
+
+jobs:
+  compile-versions:
+    strategy:
+      runs-on: 'ubuntu-latest'
+
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    # We don't want a circular dependency on setup-gcloud. We don't actually
+    # need authentication for this (the bucket is public), but gcloud refuses to
+    # run without auth.
+    - name: 'Authenticate gcloud'
+      run: |-
+        CRED_FILE="${RUNNER_TEMP}/creds.json"
+        echo "${{ secrets.SERVICE_ACCOUNT_KEY_JSON }}" > ${CRED_FILE}
+        gcloud auth login --update-adc --force --cred-file "${CRED_FILE}"
+
+    - name: 'Get versions list'
+      run: |-
+        mkdir -p ./data
+        gcloud storage objects list "gs://cloud-sdk-release" \
+          --format='value(name)' \
+          --page-size=1000 \
+          | grep -Po '(\d)+\.(\d)+\.(\d)+' \
+          | sort -h \
+          | uniq \
+          | jq -R -s 'split("\n") | map(select(length > 0))' \
+          > ./data/versions.json
+
+    - name: 'Update versions list'
+      run: |-
+        if [ -z "$(git diff ./data/versions.json)" ]; then
+          echo "No version changes - nothing to do."
+          exit 0
+        fi
+
+        git config user.name "google-github-actions-bot"
+        git config user.email "github-actions-bot@google.com"
+
+        git checkout -b "${{ env.PR_BRANCH }}"
+        git add ./data/versions.json
+        git commit -m "Update gcloud versions ($(date --iso-8601=h))"
+        git push -f origin "${{ env.PR_BRANCH }}"
+
+    - name: 'Create Pull Request'
+      uses: 'actions/github-script@v6'
+      with:
+        github-token: '${{ secrets.ACTIONS_BOT_TOKEN }}'
+        script: |-
+          const baseBranch = `${{ github.ref_name }}`;
+          const prBranch = `${{ env.PR_BRANCH }}`;
+          const prBody = `Update latest gcloud versions`;
+
+          try {
+            const listResponse = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: `open`,
+              head: `${context.repo.owner}:${prBranch}`,
+              base: baseBranch,
+            });
+
+            core.isDebug() && console.log(listResponse);
+
+            if(!listResponse.data.length) {
+              const createResponse = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Update gcloud versions`,
+                body: prBody,
+                head: prBranch,
+                base: baseBranch,
+              });
+              core.info(`Created PR #${createResponse.data.number} at ${createResponse.data.html_url}`);
+            } else {
+              const updateResponse = await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: listResponse.data[0].number,
+                title: `Update gcloud versions`,
+                body: prBody,
+              });
+              core.info(`Updated PR #${updateResponse.data.number} at ${updateResponse.data.html_url}`);
+            }
+          } catch(err) {
+            console.error(err);
+            core.setFailed(`Failed to create pull request: ${err}`);
+          }


### PR DESCRIPTION
This will be used as part of a future PR, but I want to get it in now. This queries the public bucket and uses some bash magic to generate a JSON file that contains a list of all gcloud versions.
